### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A curated list of resources for getting started with building on Ethereum - cont
 - [Node Guardians](https://nodeguardians.io/) - Learn about blockchain and programming as you navigate through a medieval game
 - [cryptozombies](https://cryptozombies.io/en/course) - Solidity beginner to intermediate hands-on tutorials
 - [Solidity by example](https://solidity-by-example.org) - An introduction to Solidity with simple examples
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/ethereum-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Smart Contract Security
 - [Cyfrin Audits Resources](https://www.cyfrin.io/resources)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A curated list of resources for getting started with building on Ethereum - cont
 - [Node Guardians](https://nodeguardians.io/) - Learn about blockchain and programming as you navigate through a medieval game
 - [cryptozombies](https://cryptozombies.io/en/course) - Solidity beginner to intermediate hands-on tutorials
 - [Solidity by example](https://solidity-by-example.org) - An introduction to Solidity with simple examples
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Smart Contract Security
 - [Cyfrin Audits Resources](https://www.cyfrin.io/resources)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/ethereum-development) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/ethereum-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.